### PR TITLE
adds choreonoid log move script.

### DIFF
--- a/bin/main.sh
+++ b/bin/main.sh
@@ -40,6 +40,9 @@ killall choreonoid
 sleep 0.5
 ./50cnoid_exec.sh
 
+echo ">>>>> 60move_cnoidlog.sh <<<<<"
+./60move_cnoidlog.sh
+
 echo ">>>>> POST PROCEDURE <<<<<"
 LC_ALL=C ls -alrt
 #LC_ALL=C ls -alrt /home/crash/core.*

--- a/bin/move_cnoidlog.sh
+++ b/bin/move_cnoidlog.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -x
+
+#
+. ./launcher.conf
+
+#
+echo ">>>>> start move choreonoid log <<<<<"
+_var="`basename $PWD`"
+
+#
+find $CNOID_PROJ_DIR/$_var-*.log -type f | xargs -I% mv -v % ./
+
+exit 0
+

--- a/config/launcher.conf.sample
+++ b/config/launcher.conf.sample
@@ -1,5 +1,6 @@
 ###
 #CNOID_CMD="/usr/local/bin/choreonoid"
+CNOID_PROJ_DIR="${HOME}/catkin_ws/devel/share/choreonoid-1.8/WRS2020/project"
 
 ###
 USE_AGX="yes" # yes or no

--- a/task/SG1L/60move_cnoidlog.sh
+++ b/task/SG1L/60move_cnoidlog.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -x
+
+#
+. ./launcher.conf
+
+#
+echo ">>>>> start move choreonoid log <<<<<"
+_var="`basename $PWD`"
+
+#
+find $CNOID_PROJ_DIR/$_var-*.log -type f | xargs -I% mv -v % ./
+
+exit 0
+

--- a/task/SG1M/60move_cnoidlog.sh
+++ b/task/SG1M/60move_cnoidlog.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -x
+
+#
+. ./launcher.conf
+
+#
+echo ">>>>> start move choreonoid log <<<<<"
+_var="`basename $PWD`"
+
+#
+find $CNOID_PROJ_DIR/$_var-*.log -type f | xargs -I% mv -v % ./
+
+exit 0
+

--- a/task/SG2/60move_cnoidlog.sh
+++ b/task/SG2/60move_cnoidlog.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -x
+
+#
+. ./launcher.conf
+
+#
+echo ">>>>> start move choreonoid log <<<<<"
+_var="`basename $PWD`"
+
+#
+find $CNOID_PROJ_DIR/$_var-*.log -type f | xargs -I% mv -v % ./
+
+exit 0
+

--- a/task/TS1/60move_cnoidlog.sh
+++ b/task/TS1/60move_cnoidlog.sh
@@ -1,0 +1,1 @@
+../../bin/move_cnoidlog.sh

--- a/task/TS2/60move_cnoidlog.sh
+++ b/task/TS2/60move_cnoidlog.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -x
+
+#
+. ./launcher.conf
+
+#
+echo ">>>>> start move choreonoid log <<<<<"
+_var="`basename $PWD`"
+
+#
+find $CNOID_PROJ_DIR/$_var-*.log -type f | xargs -I% mv -v % ./
+
+exit 0
+

--- a/task/TS3/60move_cnoidlog.sh
+++ b/task/TS3/60move_cnoidlog.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -x
+
+#
+. ./launcher.conf
+
+#
+echo ">>>>> start move choreonoid log <<<<<"
+_var="`basename $PWD`"
+
+#
+find $CNOID_PROJ_DIR/$_var-*.log -type f | xargs -I% mv -v % ./
+
+exit 0
+

--- a/task/TS4/60move_cnoidlog.sh
+++ b/task/TS4/60move_cnoidlog.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -x
+
+#
+. ./launcher.conf
+
+#
+echo ">>>>> start move choreonoid log <<<<<"
+_var="`basename $PWD`"
+
+#
+find $CNOID_PROJ_DIR/$_var-*.log -type f | xargs -I% mv -v % ./
+
+exit 0
+


### PR DESCRIPTION
Choreonoid 終了後、Choreonoid プロジェクトディレクトリ配下に出力されたシュミレーションログを task/{タスク名} ディレクトリ配下に移動させる機能を追加しました。

* launcher.conf.sample に Choreonoid のシュミレーションログが出力される、Choreonoid プロジェクトディレクトリ設定値 (CNOID_PROJ_DIR) を追加
* launcher.conf に設定されている Choreonoid プロジェクトディレクトリから、実行したタスク名のシュミレーションログを ~/.wrs/launcher/task/{タスク名} ディレクトリ配下に移動させるシェルスクリプト (bin/move_cnoidlog.sh) を追加
* bin/main.sh の Choreonoid 終了後の処理にシュミレーションのログを移動させるスクリプトを実行する処理を追加
* task/{タスク名} ディレクトリ配下に bin/move_cnoidlog.sh へのシンボリックリンクを追加

宜しくお願いいたします。